### PR TITLE
Bugfix for Issue #9 (Port number of start script is always 8000)

### DIFF
--- a/slug_trade/first_start.sh
+++ b/slug_trade/first_start.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 ./venv_setup.sh
 ./renew_db.sh
 ./start.sh $1

--- a/slug_trade/first_start.sh
+++ b/slug_trade/first_start.sh
@@ -1,3 +1,3 @@
 ./venv_setup.sh
 ./renew_db.sh
-./start.sh
+./start.sh $1

--- a/slug_trade/start.sh
+++ b/slug_trade/start.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
+PORT="$1"
+
+if [ PORT == "" ]; then
+    $PORT="8000"
+fi
+
 source env/bin/activate
 python3 manage.py makemigrations
 python3 manage.py migrate
-python3 manage.py runserver
+python3 manage.py runserver $PORT


### PR DESCRIPTION
Issue:
- The port number can't be specified on the command line when running the start script.

How to test:
- Run "start.sh" and verify that the app is running on localhost:8000
- Run "start.sh 8001" and verify that the app is running on localhost:8001
- Run "first_start.sh" and verify that the app is running on localhost:8000
- Run "first_start.sh 8001" and verify that the app is running on localhost:8001

Note: the Windows scripts still only use the default port number.